### PR TITLE
refactor/ google login 방식 변경

### DIFF
--- a/src/main/java/com/drugbox/common/oauth/platform/google/GoogleLoginParams.java
+++ b/src/main/java/com/drugbox/common/oauth/platform/google/GoogleLoginParams.java
@@ -12,10 +12,8 @@ import org.springframework.util.MultiValueMap;
 @NoArgsConstructor
 public class GoogleLoginParams implements OAuthLoginParams {
     private String authorizationCode;
-    private String fcmToken;
 
-    public GoogleLoginParams(String authorizationCode, String fcmToken) {
-        this.fcmToken = fcmToken;
+    public GoogleLoginParams(String authorizationCode) {
         this.authorizationCode = authorizationCode;
     }
 

--- a/src/main/java/com/drugbox/controller/AuthController.java
+++ b/src/main/java/com/drugbox/controller/AuthController.java
@@ -3,7 +3,7 @@ package com.drugbox.controller;
 import com.drugbox.common.exception.CustomException;
 import com.drugbox.common.exception.ErrorCode;
 import com.drugbox.common.jwt.TokenDto;
-import com.drugbox.common.oauth.platform.google.GoogleLoginParams;
+import com.drugbox.dto.request.OAuthLoginRequest;
 import com.drugbox.dto.request.UserLoginRequest;
 import com.drugbox.dto.response.IdResponse;
 import com.drugbox.service.AuthService;
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.Map;
 
 @Slf4j
@@ -26,17 +27,17 @@ public class AuthController {
     private final FCMTokenService fcmTokenService;
 
     @PostMapping("login/google")
-    public ResponseEntity<TokenDto> googleLogin(@RequestBody GoogleLoginParams params){ // auth code
-        checkFCMToken(params.getFcmToken());
-        TokenDto response = authService.googleLogin(params);
-        fcmTokenService.saveToken(response.getUserId(), params.getFcmToken());
+    public ResponseEntity<TokenDto> googleLogin(@RequestBody @Valid OAuthLoginRequest request){ // auth code
+        checkFCMToken(request.getFcmToken());
+        TokenDto response = authService.googleLogin(request);
+        fcmTokenService.saveToken(response.getUserId(), request.getFcmToken());
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/redirect/google") // 백엔드 자체 테스트용
-    public void googleRedirect(@RequestParam("code") String authCode){
+    public ResponseEntity<TokenDto> googleRedirect(@RequestParam("code") String authCode){
         log.info("\n  AuthCode:" + authCode);
-        //return ResponseEntity.ok(authService.getGoogleAccessToken(authCode));
+        return ResponseEntity.ok(authService.getGoogleAccessToken(authCode));
     }
 
     @PostMapping("/signup/pw")

--- a/src/main/java/com/drugbox/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/com/drugbox/dto/request/OAuthLoginRequest.java
@@ -1,0 +1,21 @@
+package com.drugbox.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuthLoginRequest {
+    @NotBlank // null, "", " "
+    private String accessToken;
+    @NotBlank
+    private String fcmToken;
+    @NotBlank
+    private String idToken;
+}

--- a/src/test/java/com/drugbox/CacheTest.java
+++ b/src/test/java/com/drugbox/CacheTest.java
@@ -1,8 +1,8 @@
 package com.drugbox;
 
 import com.drugbox.service.MapService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## #️⃣연관된 이슈
- close #20

## 📝작업 내용
- 기존 구글 로그인 방식은 백엔드 테스트용으로 놔둠
- 앱에서 구글 로그인시 서버로 accessToken, idToken, fcmToken 보내는 방식으로 변경
## 💬리뷰 요구사항
